### PR TITLE
Ensure ESM imports resolve to concrete files

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,8 +4,8 @@ import morgan from "morgan";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
 
-import { createUsersRouter } from "./http/routes/users";
-import { XrayService } from "./services/xrayService";
+import { createUsersRouter } from "./http/routes/users.js";
+import { XrayService } from "./services/xrayService.js";
 
 export interface AppOptions {
   service: XrayService;

--- a/src/http/routes/users.ts
+++ b/src/http/routes/users.ts
@@ -1,6 +1,6 @@
 import { Router, RequestHandler, Request, Response } from "express";
 
-import { XrayService } from "../../services/xrayService";
+import { XrayService } from "../../services/xrayService.js";
 
 export interface UsersRouteOptions {
   requireAuth?: RequestHandler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { config } from "./config";
-import { pickVlessInbound } from "./xray/inbound";
-import { XrayService } from "./services/xrayService";
-import { createApp } from "./app";
-import { firstExternalIPv4 } from "./utils/network";
+import { config } from "./config/index.js";
+import { pickVlessInbound } from "./xray/inbound.js";
+import { XrayService } from "./services/xrayService.js";
+import { createApp } from "./app.js";
+import { firstExternalIPv4 } from "./utils/network.js";
 
 async function bootstrap() {
   const inbound = pickVlessInbound(config.INBOUND_TAG);

--- a/src/services/xrayService.ts
+++ b/src/services/xrayService.ts
@@ -1,9 +1,9 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { buildVlessURI, InboundInfo } from "../xray/inbound";
-import { createSdkClient } from "../xray/clients/sdkClient";
-import { createGrpcClient } from "../xray/clients/grpcClient";
-import type { XrayClient } from "../xray/clients/types";
+import { buildVlessURI, InboundInfo } from "../xray/inbound.js";
+import { createSdkClient } from "../xray/clients/sdkClient.js";
+import { createGrpcClient } from "../xray/clients/grpcClient.js";
+import type { XrayClient } from "../xray/clients/types.js";
 
 export interface XrayServiceOptions {
   inbound: InboundInfo;

--- a/src/xray/clients/grpcClient.ts
+++ b/src/xray/clients/grpcClient.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 
-import type { XrayClient, AddUserParams } from "./types";
+import type { XrayClient, AddUserParams } from "./types.js";
 
 export interface GrpcClientOptions {
   host: string;

--- a/src/xray/clients/sdkClient.ts
+++ b/src/xray/clients/sdkClient.ts
@@ -1,4 +1,4 @@
-import type { XrayClient, AddUserParams } from "./types";
+import type { XrayClient, AddUserParams } from "./types.js";
 
 export interface SdkClientOptions {
   host: string;

--- a/src/xray/clients/types.ts
+++ b/src/xray/clients/types.ts
@@ -1,4 +1,4 @@
-import type { InboundInfo } from "../inbound";
+import type { InboundInfo } from "../inbound.js";
 
 export interface AddUserParams {
   tag: string;

--- a/src/xray/inbound.ts
+++ b/src/xray/inbound.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { execFileSync } from "child_process";
 
-import { config } from "../config";
+import { config } from "../config/index.js";
 
 export type InboundInfo = {
   tag: string;


### PR DESCRIPTION
## Summary
- update all internal imports to include explicit `.js` extensions so the emitted ESM targets concrete files
- point config consumers at `config/index.js` to avoid directory imports in the compiled output

## Testing
- npm run build
- CONFIG_PATH=/tmp/test-config.json node dist/index.js
- docker compose build xray-provisioner *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66b1c27248320bac6de64225a774b