### PR TITLE
Make trust proxy configurable via environment variable

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -31,7 +31,15 @@ export function createApp(options: AppOptions) {
   const { service, apiToken, corsOrigin } = options;
   const app = express();
 
-  app.set("trust proxy", true);
+  const trustProxyEnv = process.env.TRUST_PROXY?.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (trustProxyEnv && trustProxyEnv.length > 0) {
+    app.set("trust proxy", trustProxyEnv);
+  } else {
+    app.set("trust proxy", false);
+  }
   app.use(helmet());
   app.use(express.json());
   app.use(morgan("combined"));


### PR DESCRIPTION
## Summary
- allow configuring Express trust proxy from the TRUST_PROXY environment variable
- disable trust proxy when no proxies are specified

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6767b9a74832099645f5ebc8b0810