### PR TITLE
Fix JWT expiry typings for JWT service

### DIFF
--- a/src/auth/jwtService.ts
+++ b/src/auth/jwtService.ts
@@ -1,4 +1,5 @@
 import jwt from "jsonwebtoken";
+import type { SignOptions } from "jsonwebtoken";
 import { Types } from "mongoose";
 import { Request, Response, NextFunction } from "express";
 
@@ -10,16 +11,18 @@ export interface JWTPayload {
   exp?: number;
 }
 
+type JwtExpiry = SignOptions["expiresIn"];
+
 export interface JWTConfig {
   secret: string;
-  accessExpiry: string;
-  refreshExpiry: string;
+  accessExpiry: JwtExpiry;
+  refreshExpiry: JwtExpiry;
 }
 
 export class JWTService {
   private readonly secret: string;
-  private readonly accessExpiry: string;
-  private readonly refreshExpiry: string;
+  private readonly accessExpiry: JwtExpiry;
+  private readonly refreshExpiry: JwtExpiry;
 
   constructor(config: JWTConfig) {
     if (!config.secret || config.secret.length < 32) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import dotenv from "dotenv";
+import type { SignOptions } from "jsonwebtoken";
 
 dotenv.config();
 
@@ -35,8 +36,10 @@ const MONGO_URI =
 
 // JWT
 const JWT_SECRET = process.env.JWT_SECRET || "";
-const JWT_ACCESS_EXPIRY = process.env.JWT_ACCESS_EXPIRY || "15m";
-const JWT_REFRESH_EXPIRY = process.env.JWT_REFRESH_EXPIRY || "7d";
+const JWT_ACCESS_EXPIRY: SignOptions["expiresIn"] =
+  (process.env.JWT_ACCESS_EXPIRY || "15m") as SignOptions["expiresIn"];
+const JWT_REFRESH_EXPIRY: SignOptions["expiresIn"] =
+  (process.env.JWT_REFRESH_EXPIRY || "7d") as SignOptions["expiresIn"];
 
 // Telegram
 const BOT_TOKEN = process.env.BOT_TOKEN || "";


### PR DESCRIPTION
## Summary
- import the jsonwebtoken SignOptions type and reuse its expiresIn definition for JWT configuration
- ensure environment configuration constants for JWT expirations are typed to satisfy jsonwebtoken v9 template literal types

## Testing
- npm run build *(fails: existing TypeScript errors unrelated to JWT changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e749107ea883209fb267736c5668c3