### PR TITLE
Align session expiry with refresh token TTL

### DIFF
--- a/src/auth/__tests__/jwtServiceRefresh.test.ts
+++ b/src/auth/__tests__/jwtServiceRefresh.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { Types } from "mongoose";
+
+import { JWTService } from "../jwtService.js";
+
+const baseConfig = {
+  secret: "0123456789abcdef0123456789abcdef",
+  accessExpiry: "15m" as const,
+  refreshExpiry: "7d" as const,
+};
+
+describe("JWTService refresh expiration helper", () => {
+  it("calculates absolute expiration using the configured refresh TTL", () => {
+    const service = new JWTService(baseConfig);
+    const issuedAt = new Date("2024-01-01T00:00:00.000Z");
+
+    const expiresAt = service.getRefreshExpiresAt(issuedAt);
+
+    assert.equal(
+      expiresAt.toISOString(),
+      new Date(issuedAt.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString()
+    );
+  });
+
+  it("matches the refresh token exp claim", () => {
+    const service = new JWTService(baseConfig);
+    const { refreshToken } = service.generateTokenPair(
+      new Types.ObjectId(),
+      "123456"
+    );
+
+    const payload = service.verifyRefreshToken(refreshToken);
+    assert.ok(payload.exp, "Refresh token payload should include exp");
+    assert.ok(payload.iat, "Refresh token payload should include iat");
+
+    const helperExpires = service.getRefreshExpiresAt(
+      new Date((payload.iat as number) * 1000)
+    );
+
+    assert.equal(helperExpires.getTime(), (payload.exp as number) * 1000);
+  });
+});

--- a/src/http/routes/auth.ts
+++ b/src/http/routes/auth.ts
@@ -44,7 +44,7 @@ export function createAuthRouter(options: AuthRouteOptions) {
         );
 
         // Сохраняем refresh token в БД
-        const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 дней
+        const expiresAt = jwtService.getRefreshExpiresAt();
         await Session.create({
           userId: user._id,
           telegramId: user.telegramId,

--- a/src/models/__tests__/sessionSchema.test.ts
+++ b/src/models/__tests__/sessionSchema.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { Session } from "../index.js";
+
+describe("Session schema", () => {
+  it("defines a TTL index on expiresAt", () => {
+    const indexes = Session.schema.indexes();
+    const ttlIndex = indexes.find(([fields]) => fields.expiresAt === 1);
+
+    assert.ok(ttlIndex, "TTL index on expiresAt should be defined");
+    assert.equal(ttlIndex?.[1]?.expireAfterSeconds, 0);
+  });
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -37,6 +37,8 @@ const sessionSchema = new Schema(
   { timestamps: true }
 );
 
+sessionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
 export type SessionSchemaType = InferSchemaType<typeof sessionSchema>;
 export type SessionDocument = HydratedDocument<SessionSchemaType>;
 export const Session: Model<SessionSchemaType> =


### PR DESCRIPTION
## Summary
- add a reusable helper in the JWT service for converting the configured refresh token TTL into an absolute expiration timestamp
- apply the helper in the Telegram auth flow and ensure sessions carry a TTL index that matches the refresh token lifetime
- cover the new helper and schema behaviour with node:test suites to keep refresh token and session expirations aligned

## Testing
- node --import tsx --test src/auth/__tests__/telegramAuth.test.ts src/auth/__tests__/jwtServiceRefresh.test.ts src/models/__tests__/sessionSchema.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e752d282ac832098f3616d32cd7dc9