### PR TITLE
Mount accounts router behind JWT auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "test": "node --test --import tsx $(find src -name '*.test.ts' -print)",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "proto:fetch": "bash scripts/fetch-proto.sh",

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import rateLimit from "express-rate-limit";
 
 import { createUsersRouter } from "./http/routes/users.js";
 import { createAuthRouter } from "./http/routes/auth.js";
+import { createAccountsRouter } from "./http/routes/accounts.js";
 import { createJWTMiddleware, JWTService } from "./auth/jwtService.js";
 import { XrayService } from "./services/xrayService.js";
 
@@ -52,7 +53,9 @@ export function createApp(options: AppOptions) {
     app.use(
       cors({
         origin: corsOrigin.split(",").map((s) => s.trim()),
-        credentials: false,
+        credentials: true,
+        methods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+        allowedHeaders: ["Content-Type", "Authorization"],
       })
     );
   }
@@ -63,6 +66,7 @@ export function createApp(options: AppOptions) {
       max: 60,
       standardHeaders: true,
       legacyHeaders: false,
+      skip: (req) => req.method === "OPTIONS",
     })
   );
 
@@ -83,6 +87,12 @@ export function createApp(options: AppOptions) {
       })
     );
   }
+
+  app.use(
+    "/api/accounts",
+    requireJWTAuth,
+    createAccountsRouter(service, { requireAuth: requireJWTAuth })
+  );
 
   app.use("/", createUsersRouter(service, { requireAuth: requireApiTokenAuth }));
 

--- a/src/http/routes/__tests__/accounts.integration.test.ts
+++ b/src/http/routes/__tests__/accounts.integration.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { AddressInfo } from "node:net";
+import test from "node:test";
+
+import { createApp } from "../../../app.js";
+import { JWTService } from "../../../auth/jwtService.js";
+import { Traffic } from "../../../models/index.js";
+
+const jwtService = new JWTService({
+  secret: "test-secret-should-be-at-least-32-chars-long!!",
+  accessExpiry: "1h",
+  refreshExpiry: "7d",
+});
+
+const TELEGRAM_ID = "123456";
+const USER_ID = "507f191e810c19729de860ea";
+
+const baseServiceMock = {
+  async getUserAccounts(telegramId: string) {
+    if (telegramId !== TELEGRAM_ID) {
+      return [];
+    }
+
+    return [
+      {
+        id: "acc-1",
+        email: "user@example.com",
+        link: "vless://example",
+        remark: "Test account",
+      },
+    ];
+  },
+} as any;
+
+function buildApp() {
+  return createApp({
+    service: baseServiceMock,
+    jwtService,
+    apiToken: "",
+  });
+}
+
+test("GET /api/accounts returns accounts for an authenticated user", async () => {
+  const app = buildApp();
+  const token = jwtService.generateAccessToken(USER_ID, TELEGRAM_ID);
+
+  const originalFindOne = Traffic.findOne;
+  (Traffic as any).findOne = async () => null;
+
+  try {
+    const server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}/api/accounts`;
+
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.total, 1);
+      assert.equal(body.accounts[0].id, "acc-1");
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  } finally {
+    (Traffic as any).findOne = originalFindOne;
+  }
+});
+
+test("GET /api/accounts rejects requests without authentication", async () => {
+  const app = buildApp();
+  const server = app.listen(0);
+  const address = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${address.port}/api/accounts`;
+
+  try {
+    const response = await fetch(url);
+    assert.equal(response.status, 401);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/src/http/routes/accounts.ts
+++ b/src/http/routes/accounts.ts
@@ -18,9 +18,10 @@ export function createAccountsRouter(
    * GET /api/accounts
    * Получить все аккаунты текущего пользователя
    */
-  router.get("/", requireAuth, async (req: any, res: Response) => {
+  router.get("/", requireAuth, async (req: Request, res: Response) => {
     try {
-      const accounts = await service.getUserAccounts(req.telegramId);
+      const telegramId = req.telegramId!;
+      const accounts = await service.getUserAccounts(telegramId);
 
       // Добавляем трафик из кэша
       const accountsWithTraffic = await Promise.all(
@@ -54,13 +55,13 @@ export function createAccountsRouter(
    * POST /api/accounts
    * Создать новый аккаунт
    */
-  router.post("/", requireAuth, async (req: any, res: Response) => {
+  router.post("/", requireAuth, async (req: Request, res: Response) => {
     try {
       const { remark, flow } = req.body;
 
       const result = await service.createUser({
-        userId: req.userId,
-        telegramId: req.telegramId,
+        userId: req.userId!,
+        telegramId: req.telegramId!,
         flow,
         remark,
       });
@@ -78,9 +79,10 @@ export function createAccountsRouter(
    * GET /api/accounts/:id
    * Получить детали аккаунта
    */
-  router.get("/:id", requireAuth, async (req: any, res: Response) => {
+  router.get("/:id", requireAuth, async (req: Request, res: Response) => {
     try {
-      const accounts = await service.getUserAccounts(req.telegramId);
+      const telegramId = req.telegramId!;
+      const accounts = await service.getUserAccounts(telegramId);
       const account = accounts.find((a) => a.id === req.params.id);
 
       if (!account) {
@@ -90,7 +92,7 @@ export function createAccountsRouter(
       // Получаем актуальный трафик из Xray
       const trafficData = await service.getTraffic(
         account.id,
-        req.telegramId,
+        req.telegramId!,
         false
       );
 
@@ -112,7 +114,7 @@ export function createAccountsRouter(
    * PATCH /api/accounts/:id
    * Обновить аккаунт (remark)
    */
-  router.patch("/:id", requireAuth, async (req: any, res: Response) => {
+  router.patch("/:id", requireAuth, async (req: Request, res: Response) => {
     try {
       const { remark } = req.body;
 
@@ -120,7 +122,11 @@ export function createAccountsRouter(
         return res.status(400).json({ error: "remark is required" });
       }
 
-      await service.updateAccountRemark(req.params.id, req.telegramId, remark);
+      await service.updateAccountRemark(
+        req.params.id,
+        req.telegramId!,
+        remark
+      );
 
       res.json({ ok: true, message: "Remark updated" });
     } catch (error: any) {
@@ -133,9 +139,9 @@ export function createAccountsRouter(
    * DELETE /api/accounts/:id
    * Удалить аккаунт
    */
-  router.delete("/:id", requireAuth, async (req: any, res: Response) => {
+  router.delete("/:id", requireAuth, async (req: Request, res: Response) => {
     try {
-      await service.deleteUser(req.params.id, req.telegramId);
+      await service.deleteUser(req.params.id, req.telegramId!);
       res.json({ ok: true, message: "Account deleted" });
     } catch (error: any) {
       console.error("[DELETE /api/accounts/:id] error:", error);
@@ -149,12 +155,12 @@ export function createAccountsRouter(
    * GET /api/accounts/:id/traffic
    * Получить статистику трафика
    */
-  router.get("/:id/traffic", requireAuth, async (req: any, res: Response) => {
+  router.get("/:id/traffic", requireAuth, async (req: Request, res: Response) => {
     try {
       const reset = String(req.query.reset || "false") === "true";
       const trafficData = await service.getTraffic(
         req.params.id,
-        req.telegramId,
+        req.telegramId!,
         reset
       );
 
@@ -184,11 +190,11 @@ export function createAccountsRouter(
   router.post(
     "/:id/traffic/reset",
     requireAuth,
-    async (req: any, res: Response) => {
+    async (req: Request, res: Response) => {
       try {
         const trafficData = await service.getTraffic(
           req.params.id,
-          req.telegramId,
+          req.telegramId!,
           true
         );
 
@@ -208,9 +214,10 @@ export function createAccountsRouter(
    * GET /api/accounts/:id/qr
    * Получить QR-код для ссылки
    */
-  router.get("/:id/qr", requireAuth, async (req: any, res: Response) => {
+  router.get("/:id/qr", requireAuth, async (req: Request, res: Response) => {
     try {
-      const accounts = await service.getUserAccounts(req.telegramId);
+      const telegramId = req.telegramId!;
+      const accounts = await service.getUserAccounts(telegramId);
       const account = accounts.find((a) => a.id === req.params.id);
 
       if (!account) {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,13 @@
+import type { JWTPayload } from "../auth/jwtService.js";
+
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: string;
+      telegramId?: string;
+      jwtPayload?: JWTPayload;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- mount the accounts router at `/api/accounts` guarded by the JWT middleware while expanding CORS and rate-limit settings for Mini App clients
- extend Express request typings so routers receive `userId`/`telegramId` from the JWT middleware and update account handlers to rely on typed values
- add an integration test that exercises `/api/accounts` with and without authentication and expose an npm test runner for Node's built-in test harness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e756490d1083208d3cb224f7ff4a02