### PR TITLE
Support email-based admin user management

### DIFF
--- a/src/http/routes/__tests__/users.integration.test.ts
+++ b/src/http/routes/__tests__/users.integration.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { AddressInfo } from "node:net";
+import test from "node:test";
+
+import { createApp } from "../../../app.js";
+import { JWTService } from "../../../auth/jwtService.js";
+
+const jwtService = new JWTService({
+  secret: "test-secret-should-be-at-least-32-chars-long!!",
+  accessExpiry: "1h",
+  refreshExpiry: "7d",
+});
+
+const API_TOKEN = "test-api-token";
+
+function createServiceMock() {
+  const inbound = {
+    tag: "vless-inbound",
+    port: 443,
+    security: "tls",
+    network: "tcp",
+    sni: "vpn.example.com",
+    pbk: undefined,
+    path: undefined,
+    hostHeader: undefined,
+  };
+
+  const mock = {
+    inbound,
+    lastCreateInput: null as any,
+    lastDeletedEmail: null as string | null,
+    lastTrafficArgs: null as { email: string; reset: boolean } | null,
+    getInboundInfo() {
+      return inbound;
+    },
+    getPublicHost() {
+      return "public.example.com";
+    },
+    async createAdminUser(input: any) {
+      mock.lastCreateInput = input;
+      return {
+        id: input.email,
+        uuid: "generated-uuid",
+        email: input.email,
+        inboundTag: inbound.tag,
+        port: inbound.port,
+        security: inbound.security,
+        link: "vless://generated",
+        raw: {},
+      };
+    },
+    async deleteUserByEmail(email: string) {
+      mock.lastDeletedEmail = email;
+    },
+    async getTrafficByEmail(email: string, reset: boolean = false) {
+      mock.lastTrafficArgs = { email, reset };
+      return {
+        email,
+        uplink: 100,
+        downlink: 200,
+        total: 300,
+        resetApplied: reset,
+      };
+    },
+  };
+
+  return mock;
+}
+
+function buildApp(serviceMock: any) {
+  return createApp({
+    service: serviceMock,
+    jwtService,
+    apiToken: API_TOKEN,
+  });
+}
+
+async function withServer(app: ReturnType<typeof buildApp>, cb: (url: string) => Promise<void>) {
+  const server = app.listen(0);
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await cb(baseUrl);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("GET /info returns inbound details when authorized", async () => {
+  const serviceMock = createServiceMock();
+  const app = buildApp(serviceMock as any);
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/info`, {
+      headers: { Authorization: `Bearer ${API_TOKEN}` },
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.inboundTag, serviceMock.inbound.tag);
+    assert.equal(body.port, serviceMock.inbound.port);
+  });
+});
+
+test("POST /users creates a user with provided email", async () => {
+  const serviceMock = createServiceMock();
+  const app = buildApp(serviceMock as any);
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: "admin@example.com", flow: "xtls-rprx-vision" }),
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.email, "admin@example.com");
+    assert.equal(serviceMock.lastCreateInput.email, "admin@example.com");
+    assert.equal(serviceMock.lastCreateInput.flow, "xtls-rprx-vision");
+  });
+});
+
+test("GET /users/:email/traffic proxies traffic data", async () => {
+  const serviceMock = createServiceMock();
+  const app = buildApp(serviceMock as any);
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/users/admin%40example.com/traffic?reset=true`,
+      {
+        headers: { Authorization: `Bearer ${API_TOKEN}` },
+      }
+    );
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.email, "admin@example.com");
+    assert.equal(body.resetApplied, true);
+    assert.equal(serviceMock.lastTrafficArgs?.email, "admin@example.com");
+    assert.equal(serviceMock.lastTrafficArgs?.reset, true);
+  });
+});
+
+test("DELETE /users/:email removes the user via service", async () => {
+  const serviceMock = createServiceMock();
+  const app = buildApp(serviceMock as any);
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users/admin%40example.com`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${API_TOKEN}` },
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(serviceMock.lastDeletedEmail, "admin@example.com");
+  });
+});
+
+test("/users endpoints require API token", async () => {
+  const serviceMock = createServiceMock();
+  const app = buildApp(serviceMock as any);
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "missing-auth@example.com" }),
+    });
+
+    assert.equal(response.status, 401);
+    assert.equal(serviceMock.lastCreateInput, null);
+  });
+});

--- a/src/http/routes/users.ts
+++ b/src/http/routes/users.ts
@@ -48,7 +48,7 @@ export function createUsersRouter(
       const flow = req.body?.flow?.toString();
       const remark = req.body?.remark?.toString();
 
-      const result = await service.createUser({ email, flow, remark });
+      const result = await service.createAdminUser({ email, flow, remark });
       res.json(result);
     } catch (err: any) {
       console.error("[POST /users] error:", err);
@@ -64,7 +64,7 @@ export function createUsersRouter(
     async (req: Request, res: Response) => {
       try {
         const email = decodeURIComponent(req.params.email);
-        await service.deleteUser(email);
+        await service.deleteUserByEmail(email);
         res.json({ ok: true, email });
       } catch (err: any) {
         console.error("[DELETE /users/:email] error:", err);
@@ -82,7 +82,7 @@ export function createUsersRouter(
       try {
         const email = decodeURIComponent(req.params.email);
         const reset = String(req.query.reset || "false") === "true";
-        const stats = await service.getTraffic(email, reset);
+        const stats = await service.getTrafficByEmail(email, reset);
         res.json({ email, ...stats, resetApplied: !!reset });
       } catch (err: any) {
         console.error("[GET /users/:email/traffic] error:", err);


### PR DESCRIPTION
## Summary
- add email-focused helper methods to `XrayService` for creating, deleting, and fetching traffic without Telegram context
- update the admin users HTTP routes to call the new helpers when handling CRUD requests
- add integration tests for the `/info` and `/users` admin endpoints, including API token authorization requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e765f4e6748320b80714d2ce856e63