### PR TITLE
Fix traffic stats response duplication and null flow handling

### DIFF
--- a/src/http/routes/users.ts
+++ b/src/http/routes/users.ts
@@ -83,7 +83,12 @@ export function createUsersRouter(
         const email = decodeURIComponent(req.params.email);
         const reset = String(req.query.reset || "false") === "true";
         const stats = await service.getTrafficByEmail(email, reset);
-        res.json({ email, ...stats, resetApplied: !!reset });
+        const { email: statsEmail, resetApplied, ...restStats } = stats ?? {};
+        res.json({
+          email: statsEmail ?? email,
+          resetApplied: resetApplied ?? !!reset,
+          ...restStats,
+        });
       } catch (err: any) {
         console.error("[GET /users/:email/traffic] error:", err);
         const msg = err?.details || err?.message || "Internal error";

--- a/src/services/xrayService.ts
+++ b/src/services/xrayService.ts
@@ -327,7 +327,7 @@ export class XrayService {
       uuid: acc.uuid,
       remark: acc.remark,
       link: acc.link,
-      flow: acc.flow,
+      flow: acc.flow ?? undefined,
       security: acc.security,
       port: acc.port,
       createdAt: acc.createdAt,
@@ -360,7 +360,7 @@ export class XrayService {
     const { link, raw } = buildVlessURI({
       uuid: account.uuid,
       email: account.email,
-      flow: account.flow,
+      flow: account.flow ?? undefined,
       remark,
       inbound: this.inbound,
       publicHost: this.publicHost,


### PR DESCRIPTION
## Summary
- ensure the traffic route response normalizes fields before returning to avoid duplicate properties
- normalize nullable flow values when mapping accounts and rebuilding VLESS URIs to satisfy type expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7680e56f48320b633dfc34b8fa577