### PR TITLE
Expand CORS headers for Telegram web app

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,11 @@ export function createApp(options: AppOptions) {
         origin: corsOrigin.split(",").map((s) => s.trim()),
         credentials: true,
         methods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-        allowedHeaders: ["Content-Type", "Authorization"],
+        allowedHeaders: [
+          "Content-Type",
+          "Authorization",
+          "Telegram-Web-App-Data",
+        ],
       })
     );
   }


### PR DESCRIPTION
## Summary
- extend the allowed CORS headers to include the Telegram Web App data header so requests succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea3afbb5c48320b6a457edc0b9e45d