### PR TITLE
Allow anoname.ru frontend via CORS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       NODE_ENV: production
       HTTP_ADDR: 0.0.0.0:8080
       GRPC_ADDR: 127.0.0.1:10085
+      CORS_ORIGIN: https://anoname.ru
       X_PUBLIC_HOST: ${X_PUBLIC_HOST}
       X_IN_TAG: ${X_IN_TAG}
       X_DEFAULT_FLOW: ${X_DEFAULT_FLOW:-xtls-rprx-vision}


### PR DESCRIPTION
## Summary
- configure the docker-compose backend service to accept requests from https://anoname.ru via CORS

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ea425d918c8320995a3276f372558d